### PR TITLE
Fix vapor deploy

### DIFF
--- a/src/FilamentAccessManagementServiceProvider.php
+++ b/src/FilamentAccessManagementServiceProvider.php
@@ -107,33 +107,35 @@ class FilamentAccessManagementServiceProvider extends PluginServiceProvider
 
     public function packageBooted(): void
     {
-        $configFiles = [
-            __DIR__.'/../vendor/spatie/laravel-permission/config/permission.php' => 'permission.php',
-        ];
-
-        $migrationFiles = [
-            //
-        ];
-
-        // publish config
-        foreach ($configFiles as $filePath => $fileName) {
-            $this->publishes([
-                $filePath => config_path($fileName),
-            ], "{$this->package->shortName()}-config");
-        }
-
-        $now = Carbon::now();
-
-        // publish migrations
-        foreach ($migrationFiles as $filePath => $fileName) {
-            $this->publishes([
-                $filePath => $this->generateMigrationName(
-                    $fileName,
-                    $now
-                ), ], "{$this->package->shortName()}-migrations");
-
-            if ($this->package->runsMigrations) {
-                $this->loadMigrationsFrom($filePath);
+        if ($this->app->runningInConsole()) {
+            $configFiles = [
+                __DIR__.'/../vendor/spatie/laravel-permission/config/permission.php' => 'permission.php',
+            ];
+    
+            $migrationFiles = [
+                //
+            ];
+    
+            // publish config
+            foreach ($configFiles as $filePath => $fileName) {
+                $this->publishes([
+                    $filePath => config_path($fileName),
+                ], "{$this->package->shortName()}-config");
+            }
+    
+            $now = Carbon::now();
+    
+            // publish migrations
+            foreach ($migrationFiles as $filePath => $fileName) {
+                $this->publishes([
+                    $filePath => $this->generateMigrationName(
+                        $fileName,
+                        $now
+                    ), ], "{$this->package->shortName()}-migrations");
+    
+                if ($this->package->runsMigrations) {
+                    $this->loadMigrationsFrom($filePath);
+                }
             }
         }
 

--- a/src/FilamentAccessManagementServiceProvider.php
+++ b/src/FilamentAccessManagementServiceProvider.php
@@ -65,11 +65,6 @@ class FilamentAccessManagementServiceProvider extends PluginServiceProvider
         ];
     }
 
-    protected function getResources(): array
-    {
-        return Utils::getResources();
-    }
-
     protected function getPages(): array
     {
         return array_merge(Utils::getPages(), [
@@ -85,10 +80,6 @@ class FilamentAccessManagementServiceProvider extends PluginServiceProvider
 
         Config::push('app.providers', \Spatie\Permission\PermissionServiceProvider::class);
 
-        // middleware
-        // foreach (config('filament-access-management.filament.middleware.base', []) as $middleware) {
-        //     Config::push('filament.middleware.base', $middleware);
-        // }
         parent::packageRegistered();
     }
 

--- a/src/FilamentAccessManagementServiceProvider.php
+++ b/src/FilamentAccessManagementServiceProvider.php
@@ -84,8 +84,6 @@ class FilamentAccessManagementServiceProvider extends PluginServiceProvider
             return app(FilamentAccessManagement::class);
         });
 
-        Config::push('app.providers', \Spatie\Permission\PermissionServiceProvider::class);
-
         // middleware
         foreach (config('filament-access-management.filament.middleware.base', []) as $middleware) {
             Config::push('filament.middleware.base', $middleware);

--- a/src/FilamentAccessManagementServiceProvider.php
+++ b/src/FilamentAccessManagementServiceProvider.php
@@ -65,11 +65,20 @@ class FilamentAccessManagementServiceProvider extends PluginServiceProvider
         ];
     }
 
+    protected function getResources(): array
+    {
+        return [
+            Resources\UserResource::class,
+            Resources\RoleResource::class,
+            Resources\PermissionResource::class,
+        ];
+    }
+
     protected function getPages(): array
     {
-        return array_merge(Utils::getPages(), [
-            Pages\Error::class
-        ]);
+        return [
+            Pages\Error::class,
+        ];
     }
 
     public function packageRegistered(): void

--- a/src/FilamentAccessManagementServiceProvider.php
+++ b/src/FilamentAccessManagementServiceProvider.php
@@ -86,9 +86,9 @@ class FilamentAccessManagementServiceProvider extends PluginServiceProvider
         Config::push('app.providers', \Spatie\Permission\PermissionServiceProvider::class);
 
         // middleware
-        foreach (config('filament-access-management.filament.middleware.base', []) as $middleware) {
-            Config::push('filament.middleware.base', $middleware);
-        }
+        // foreach (config('filament-access-management.filament.middleware.base', []) as $middleware) {
+        //     Config::push('filament.middleware.base', $middleware);
+        // }
         parent::packageRegistered();
     }
 

--- a/src/FilamentAccessManagementServiceProvider.php
+++ b/src/FilamentAccessManagementServiceProvider.php
@@ -28,7 +28,6 @@ class FilamentAccessManagementServiceProvider extends PluginServiceProvider
                 $command
                     ->publishConfigFile()
                     ->publishMigrations()
-                    // ->askToRunMigrations()
                     ->endWith(function (InstallCommand $command) {
                         $command->call('migrate');
 
@@ -85,7 +84,7 @@ class FilamentAccessManagementServiceProvider extends PluginServiceProvider
             return app(FilamentAccessManagement::class);
         });
 
-        // Config::push('app.providers', \Spatie\Permission\PermissionServiceProvider::class);
+        Config::push('app.providers', \Spatie\Permission\PermissionServiceProvider::class);
 
         // middleware
         foreach (config('filament-access-management.filament.middleware.base', []) as $middleware) {
@@ -119,8 +118,5 @@ class FilamentAccessManagementServiceProvider extends PluginServiceProvider
                 $filePath => config_path($fileName),
             ], "{$this->package->shortName()}-config");
         }
-
-        $now = Carbon::now();
-
     }
 }

--- a/src/FilamentAuthServiceProvider.php
+++ b/src/FilamentAuthServiceProvider.php
@@ -2,8 +2,12 @@
 
 namespace SolutionForest\FilamentAccessManagement;
 
+use Filament\Facades\Filament;
+use Filament\Navigation\NavigationBuilder;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
+use SolutionForest\FilamentAccessManagement\Facades\FilamentAuthenticate;
+use SolutionForest\FilamentAccessManagement\Http\Auth\Permission;
 
 class FilamentAuthServiceProvider extends ServiceProvider
 {
@@ -15,5 +19,50 @@ class FilamentAuthServiceProvider extends ServiceProvider
     public function register()
     {
         //
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        Filament::serving(function () {
+            $this->configureNavigation();
+            $this->configureComponent();
+        });
+    }
+
+    protected function configureNavigation()
+    {
+        if (config('filament-access-management.filament.navigation.enabled', false)) {
+            Filament::navigation(function (NavigationBuilder $builder) {
+                if ($customBuilder = FilamentAuthenticate::getCustomNavigation()) {
+                    $builder = $customBuilder;
+                }
+
+                return $builder->groups(FilamentAuthenticate::getUserNavigationGroups());
+            });
+        }
+    }
+
+    protected function configureComponent()
+    {
+        if (config('filament-access-management.filament.path_permission_checking.action', false)) {
+            \Filament\Support\Actions\BaseAction::configureUsing(function (\Filament\Support\Actions\BaseAction $component) {
+                if (method_exists($component, 'getUrl')) {
+                    $component->hidden(function () use ($component) {
+                        $url = $component->getUrl();
+
+                        if (empty($url)) {
+                            return false;
+                        }
+
+                        return ! Permission::checkPermission($url);
+                    });
+                }
+            });
+        }
     }
 }

--- a/src/FilamentAuthServiceProvider.php
+++ b/src/FilamentAuthServiceProvider.php
@@ -2,14 +2,8 @@
 
 namespace SolutionForest\FilamentAccessManagement;
 
-use Filament\Facades\Filament;
-use Filament\Navigation\NavigationBuilder;
-use Filament\Navigation\NavigationGroup;
-use Filament\Navigation\NavigationItem;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
-use SolutionForest\FilamentAccessManagement\Facades\FilamentAuthenticate;
-use SolutionForest\FilamentAccessManagement\Http\Auth\Permission;
 
 class FilamentAuthServiceProvider extends ServiceProvider
 {
@@ -21,50 +15,5 @@ class FilamentAuthServiceProvider extends ServiceProvider
     public function register()
     {
         //
-    }
-
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        Filament::serving(function () {
-            $this->configureNavigation();
-            $this->configureComponent();
-        });
-    }
-
-    protected function configureNavigation()
-    {
-        if (config('filament-access-management.filament.navigation.enabled', false)) {
-            Filament::navigation(function (NavigationBuilder $builder) {
-                if ($customBuilder = FilamentAuthenticate::getCustomNavigation()) {
-                    $builder = $customBuilder;
-                }
-
-                return $builder->groups(FilamentAuthenticate::getUserNavigationGroups());
-            });
-        }
-    }
-
-    protected function configureComponent()
-    {
-        if (config('filament-access-management.filament.path_permission_checking.action', false)) {
-            \Filament\Support\Actions\BaseAction::configureUsing(function (\Filament\Support\Actions\BaseAction $component) {
-                if (method_exists($component, 'getUrl')) {
-                    $component->hidden(function () use ($component) {
-                        $url = $component->getUrl();
-
-                        if (empty($url)) {
-                            return false;
-                        }
-
-                        return ! Permission::checkPermission($url);
-                    });
-                }
-            });
-        }
     }
 }


### PR DESCRIPTION
The order of execution at the function FilamentAccessManagementServiceProvider impacted on the Laravel Vapor Health Check deploy.

So I just fixed the order of calling to access the config function without impact anything on the current source code.