### PR TITLE
feat: set default user model in filament access management configuration

### DIFF
--- a/config/filament-access-management.php
+++ b/config/filament-access-management.php
@@ -15,6 +15,8 @@ return [
             '/login',
             '/error*',
         ],
+        // Default user model
+        'model' => App\Models\User::class,
     ],
     'filament' => [
         'path_permission_checking' => [

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -36,7 +36,7 @@ class Utils
 
     public static function getUserModel(): string
     {
-        return config('auth.providers.users.model', 'App\\Models\\User');
+        return config('filament-access-management.auth.model', 'App\\Models\\User');
     }
 
     public static function getRoleModel(): string


### PR DESCRIPTION
feat: Set default user model in thread access management configuration so we can modify it in cases where the primary user is not from the user model