### PR TITLE
translate label of menu page

### DIFF
--- a/resources/lang/en/filament-access-management.php
+++ b/resources/lang/en/filament-access-management.php
@@ -39,6 +39,7 @@ return [
     */
 
     'section.group' => 'Admin',
+    'section.menu' => 'Menu',
     'section.users' => 'Users',
     'section.user' => 'User',
     'section.permission' => 'Permission',

--- a/src/Pages/Menu.php
+++ b/src/Pages/Menu.php
@@ -126,6 +126,11 @@ class Menu extends TreePage
         return $action;
     }
 
+    public static function getNavigationLabel(): string
+    {
+        return strval(__('filament-access-management::filament-access-management.section.menu'));
+    }
+
     public static function getNavigationGroup(): ?string
     {
         return strval(__('filament-access-management::filament-access-management.section.group'));


### PR DESCRIPTION
For the translation of `Menu` in the sidebar, this key needs to be added to the translate file so that it can be translatable and modifiable